### PR TITLE
Added missing 'each' prefix to array modifiers

### DIFF
--- a/HanserModelica/SynchronousMachines/SMEE_DOL.mo
+++ b/HanserModelica/SynchronousMachines/SMEE_DOL.mo
@@ -28,7 +28,7 @@ model SMEE_DOL "Electrical excited synchronous machine starting direct on line"
     statorCoreParameters(VRef=100),
     strayLoadParameters(IRef=100),
     brushParameters(ILinear=0.01),
-    ir(fixed=true),
+    ir(each fixed=true),
     wMechanical(fixed=true),
     m=m,
     Rs=smeeData.Rs*m/3,

--- a/HanserModelica/SynchronousMachines/SMEE_Synchronization1.mo
+++ b/HanserModelica/SynchronousMachines/SMEE_Synchronization1.mo
@@ -33,7 +33,7 @@ model SMEE_Synchronization1 "Electrical excited synchronous machine synchronized
     statorCoreParameters(VRef=100),
     strayLoadParameters(IRef=100),
     brushParameters(ILinear=0.01),
-    ir(fixed=true),
+    ir(each fixed=true),
     wMechanical(fixed=true,start=wNominal),
     m=m,
     Rs=smeeData.Rs*m/3,

--- a/HanserModelica/SynchronousMachines/Templates/SMEE_ShortCircuit.mo
+++ b/HanserModelica/SynchronousMachines/Templates/SMEE_ShortCircuit.mo
@@ -32,7 +32,7 @@ partial model SMEE_ShortCircuit "Template for short circuits of electrical excit
     statorCoreParameters(VRef=100),
     strayLoadParameters(IRef=100),
     brushParameters(ILinear=0.01),
-    ir(fixed=true),
+    ir(each fixed=true),
     m=m,
     Rs=smeeData.Rs*m/3,
     Lssigma=smeeData.Lssigma*m/3,


### PR DESCRIPTION
@christiankral , this commit fixes an issue that prevents 7 models of HanserModelica to run in OMC with the new frontend, see [report](https://libraries.openmodelica.org/branches/newInst/HanserModelica/HanserModelica.html).

Once this is merged, there will be only one remaining issue with three similar models, that we should fix in the next few weeks in the compiler.