### PR TITLE
Final modifier fixes issue with OMC

### DIFF
--- a/HanserModelica/Machines/TestSingleLayer12over12.mo
+++ b/HanserModelica/Machines/TestSingleLayer12over12.mo
@@ -4,7 +4,7 @@ model TestSingleLayer12over12 "Test model of SingleLayer12over12"
   import Modelica.Constants.pi;
   parameter HanserModelica.Machines.Records.Winding winding=
     HanserModelica.Machines.Records.SingleLayer12over12() "Winding";
-  parameter Complex N[winding.m]=HanserModelica.Machines.Functions.complexTurns(
+  final parameter Complex N[winding.m]=HanserModelica.Machines.Functions.complexTurns(
     winding) "Complex numbers of turns";
   parameter Real effectiveTurns[winding.m] = Modelica.ComplexMath.'abs'(N)
     "Magnitudes of complex numbers of turns";


### PR DESCRIPTION
@christiankral this small change (which makes sense, since you don't want to change that binding at runtime) fixes the problem with OMC running the TestDoubleLayerXoverY models, see comment [here](https://github.com/OpenModelica/OpenModelica/issues/8539#issuecomment-1096858930).

Please also tag a new release, so that we test the updated version. 

Thanks!